### PR TITLE
Fix README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,14 @@ Simple example:
 
 
 const templater = require('anytv-templater');
+const i18n = require('anytv-i18n');
 
+// make sure i18n is loaded before passing it on templater
 
 // on server.js
 templater.configure({
-
-    i18n: {
-        languages_url: 'https://translation.server.com/:project/latest/languages.json',
-        translations_url: 'https://translation.server.com/:project/latest/:lang.json',
-        project: 'project_name',
-        default: 'en'
-    },
+    
+    i18n: i18n,
 
     templates_dir: 'directory/of/templates'
 });


### PR DESCRIPTION
Changes:
- Updated instructions on how to use the library

Before, templater hosts its own i18n, so it accepts the config for it.

Right now, templater does not have its own translator(i18n) anymore. It accepts a configured i18n object and uses it for translations. Passing the responsibility of loading i18n in the library user.